### PR TITLE
update xdebug version to last stable, modify obsolete package name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
 FROM php:7.1-fpm
 
 # Install PHP extensions and PECL modules.
-RUN apt-get update && deps=" \
+RUN apt-get update
+
+RUN deps=" \
         apt-utils \
         libfreetype6-dev \
         libjpeg62-turbo-dev \
-        libpng12-dev \
+        libpng-dev \
         libcurl4-openssl-dev \
         libicu-dev \
         libmcrypt-dev \
@@ -14,11 +16,12 @@ RUN apt-get update && deps=" \
         git \
         vim \
     " \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y -q $deps \
-    && docker-php-ext-install opcache mcrypt intl \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y -q $deps
+
+RUN docker-php-ext-install opcache mcrypt intl \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install gd \
-    && pecl install redis xdebug-2.5.0 \
+    && pecl install redis xdebug-2.6.0 \
     && docker-php-ext-enable redis xdebug \
     && rm -r /var/lib/apt/lists/*
 


### PR DESCRIPTION
Change la version de  Xdebug de 2.5.0 à 2.6.0.
Motivé par des erreurs de couverture de code non-détectée en utilisant PHPUnit / PHP Code Coverage .